### PR TITLE
Edit the recipient of the payToMint function in the frontend.

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -66,8 +66,7 @@ function NFTImage({ tokenId, getCount }) {
   };
 
   const mintToken = async () => {
-    const connection = contract.connect(signer);
-    const addr = connection.address;
+    const addr = await signer.getAddress();
     const result = await contract.payToMint(addr, metadataURI, {
       value: ethers.utils.parseEther('0.05'),
     });


### PR DESCRIPTION
Hi Jeff,

Thanks for your nice tutorial on building a web3 app from scratch.

However by implementing this tuto, I found a potential mistake. Indeed, I was not able to see my newly minted NFT in Metamask (Error: "You are not the owner of this collectible so you can't add it").

After some investigations in the code, I found that you set the recipient of the `payToMint` function to the **contract** address itself. This should be the **buyer** address. Of course the 0.05 ETH will be sent to the contract account but the newly minted NFT **should be sent to the buyer account**.

After editing these 2 lines of code, my NFT appears in my Metamask wallet as expected.

Thanks